### PR TITLE
Fix JSON.parse failure

### DIFF
--- a/src/getList.ts
+++ b/src/getList.ts
@@ -29,7 +29,7 @@ export const getList = <M extends Model>(
   })
 
 export const _parseFilter = (filter: string) =>
-  mapValues(JSON.parse(filter), value => {
+  mapValues(JSON.parse(filter || '{}'), value => {
     if (typeof value === 'string' && value.indexOf('%') !== -1) {
       return { [Op.like]: value }
     }


### PR DESCRIPTION
Fix JSON.parse failure when there's no filter parameter like `http://localhost:8080/resources`. `http://localhost:8080/resources?filter={}` is ok. React Admin seems not to add filter parameter as default.

```
SyntaxError: Unexpected token u in JSON at position 0
at JSON.parse (<anonymous>)
at _parseFilter (/src/node_modules/express-sequelize-crud/lib/getList.js:39:60)
...
```