### PR TITLE
feat: improve search customizability, efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ app.use(
         ...findOptions,
         where: {
           [Op.or]: [
-            { address: { [Op.ilike]: `${q}%` } },
-            { zipCode: { [Op.ilike]: `${q}%` } },
-            { city: { [Op.ilike]: `${q}%` } },
+            { address: { [Op.iLike]: `${q}%` } },
+            { zipCode: { [Op.iLike]: `${q}%` } },
+            { city: { [Op.iLike]: `${q}%` } },
           ],
         },
       })
@@ -107,7 +107,17 @@ When searching `some stuff`, the following records will be returned in this orde
 2. records that have searchable fields that contain both `some` and `stuff`
 3. records that have searchable fields that contain one of `some` or `stuff`
 
-The search is case insensitive.
+The search is case insensitive by default. You can customize the search to make it case sensitive or use a scope:
+
+```ts
+import { Op } from 'sequelize'
+
+const search = searchFields(User, ['address', 'zipCode', 'city'], Op.like)
+
+crud('/admin/users', User, {
+  search: (q, limit) => search(q, limit, { ownerId: req.user.id }),
+})
+```
 
 #### Filters
 

--- a/src/getList/searchList.spec.ts
+++ b/src/getList/searchList.spec.ts
@@ -48,4 +48,48 @@ describe('crud', () => {
       },
     ])
   })
+
+  it('supports alternate comparators', () => {
+    expect(prepareQueries(['field1'])('some mustach', Op.like)).toEqual([
+      {
+        [Op.or]: [
+          {
+            field1: { [Op.like]: '%some mustach%' },
+          },
+        ],
+      },
+      {
+        [Op.and]: [
+          {
+            [Op.or]: [{ field1: { [Op.like]: '%some%' } }],
+          },
+          {
+            [Op.or]: [{ field1: { [Op.like]: '%mustach%' } }],
+          },
+        ],
+      },
+      {
+        [Op.or]: [
+          {
+            [Op.or]: [{ field1: { [Op.like]: '%some%' } }],
+          },
+          {
+            [Op.or]: [{ field1: { [Op.like]: '%mustach%' } }],
+          },
+        ],
+      },
+    ])
+  })
+
+  it('does only one lookup for single tokens', () => {
+    expect(prepareQueries(['field1'])('mustach')).toEqual([
+      {
+        [Op.or]: [
+          {
+            field1: { [Op.iLike]: '%mustach%' },
+          },
+        ],
+      },
+    ])
+  })
 })


### PR DESCRIPTION
greetings!

i use SQLite in dev & test which does not support ILIKE. there might also be cases where case-insensitivity is simply not desired, and maybe even use cases for other comparators.

hence this shot add supporting them.

disclaimer: i'm new to TS. there was some type-checking error that already happened before these changes which i ignored.

*edit:*

i've added a few more things to the pr:

- an option to limit the scope of results (this is already possible with all other actions, but not search so far)
- skipping redundant extra queries if there is just one token, probably a common case
- some fixes for inputs like "foo&nbsp;&nbsp;&nbsp;bar", or "foo " (preventing `ILIKE %%` queries)